### PR TITLE
DXLog support

### DIFF
--- a/Properties/Settings.Designer.cs
+++ b/Properties/Settings.Designer.cs
@@ -866,7 +866,7 @@ namespace wtKST.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("wtKST")]
+        [global::System.Configuration.DefaultSettingValueAttribute("STN1")]
         public string WinTest_StationName {
             get {
                 return ((string)(this["WinTest_StationName"]));
@@ -900,6 +900,30 @@ namespace wtKST.Properties {
             }
         }
         
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool DXLog_Sync_active {
+            get {
+                return ((bool)(this["DXLog_Sync_active"]));
+            }
+            set {
+                this["DXLog_Sync_active"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("STN1")]
+        public string DXLog_StationName {
+            get {
+                return ((string)(this["DXLog_StationName"]));
+            }
+            set {
+                this["DXLog_StationName"] = value;
+            }
+        }
+
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]

--- a/Properties/Settings.settings
+++ b/Properties/Settings.settings
@@ -213,7 +213,7 @@
       <Value Profile="(Default)">qrv_local.xml</Value>
     </Setting>
     <Setting Name="WinTest_StationName" Type="System.String" Scope="User">
-      <Value Profile="(Default)">wtKST</Value>
+      <Value Profile="(Default)">STN1</Value>
     </Setting>
     <Setting Name="WinTest_NetworkSync_active" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
@@ -256,6 +256,12 @@
     </Setting>
     <Setting Name="N1MM_UpdateInterval" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">10</Value>
+    </Setting>
+    <Setting Name="DXLog_Sync_active" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="DXLog_StationName" Type="System.String" Scope="User">
+      <Value Profile="(Default)">STN1</Value>
     </Setting>
   </Settings>
 </SettingsFile>

--- a/WinTest/DXLog/DXLogNetworkClient.cs
+++ b/WinTest/DXLog/DXLogNetworkClient.cs
@@ -1,0 +1,220 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WinTest.DXLog
+{
+    public class DXLogNetworkClient
+    {
+        private const int Port = 9888;
+        private UdpClient _udpClient;
+        private int _messageId;
+
+        private readonly Dictionary<string, NetworkMsgStatusInfo> _availableStations = new Dictionary<string, NetworkMsgStatusInfo>();
+
+        public DXLogNetworkClient()
+        {
+            
+        }
+
+        public event EventHandler<DXQSO> DXLogQsoReceived;
+        public event EventHandler<NetworkMsgStatusInfo> StationJoinedNetwork;
+        public event EventHandler<string> StationLeftNetwork;
+        
+        public List<NetworkMsgStatusInfo> AvailableStations => _availableStations.Values.ToList();
+
+        public async Task StartListeningAsync()
+        {
+            try
+            {
+                // Enable port sharing
+                _udpClient = new UdpClient();
+                _udpClient.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+                _udpClient.Client.Bind(new IPEndPoint(IPAddress.Any, Port));
+
+                SendSyncRequest();
+
+                // Thread to listen for network messages.
+                Task.Run(async () =>
+                {
+                    while (true)
+                    {
+                        var msg = await _udpClient.ReceiveAsync();
+                        ProcessNetworkMessage(msg.Buffer);
+                    }
+                });
+                
+                // Thread to clean out stations no longer on the network
+                Task.Run(() =>
+                {
+                    while (true)
+                    {
+                        foreach (var station in _availableStations.Where(s => (DateTime.UtcNow - s.Value.LastSeenUtc).TotalSeconds >= 30).ToList())
+                        {
+                            // If a station has not been seen for 30 seconds, we remove them from the available list and fire an event.
+                            StationLeftNetwork?.Invoke(this, station.Key);
+                            _availableStations.Remove(station.Key);
+                        }
+
+                        // Add 30s delay to avoid tight loop.
+                        Task.Delay(30000).Wait(); 
+                    }
+                });
+                
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error: {ex.Message}");
+            }
+        }
+
+
+        public void StopListening()
+        {
+            _udpClient?.Close();
+            _udpClient = null;
+        }
+
+        private int GetMessageId()
+        {
+            _messageId = _messageId % 9999 + 1;
+            return _messageId;
+        }
+
+        private void SendSyncRequest(int startQso = 0)
+        {
+            var msgSyncRequest = new NetworkMsgSyncRequest
+            {
+                IDQSO = startQso.ToString(),
+                SyncPhase = 0
+            };
+
+            var networkMessage = new NetworkMessage
+            {
+                MsgDestination = "ALL",
+                MsgSender = "WTKST",
+                MsgID = GetMessageId().ToString(),
+                MsgType = "SRQ",
+                MsgData = msgSyncRequest.ToByteArray()
+            };
+
+            var rawMessage = networkMessage.ToByteArray();
+
+            _udpClient.Send(rawMessage, rawMessage.Length, new IPEndPoint(IPAddress.Broadcast, Port));
+
+            //Console.WriteLine($"SENT SRQ {startQso}");
+
+        }
+
+        private void RequestQso(string qsoId, string originStnID)
+        {
+            var msgSyncRequest = new NetworkMsgSync
+            {
+                QSOs =
+                {
+                    [0] = new NetworkMsgSync.SyncQSODesc { IDQSO = qsoId },
+                    [1] = new NetworkMsgSync.SyncQSODesc { IDQSO = "0" }
+                }
+            };
+
+            var networkMessage = new NetworkMessage
+            {
+                MsgDestination = originStnID,
+                MsgSender = "WTKST",
+                MsgID = GetMessageId().ToString(),
+                MsgType = "SSQ",
+                MsgData = msgSyncRequest.ToByteArray()
+            };
+
+            var rawMessage = networkMessage.ToByteArray();
+
+            _udpClient.Send(rawMessage, rawMessage.Length, new IPEndPoint(IPAddress.Broadcast, Port));
+            //Console.WriteLine($"SENT SSQ {qsoId} to {originStnID}");
+        }
+
+
+        private void ProcessNetworkMessage(byte[] rxMessage)
+        {
+            try
+            {
+                var networkMessage = new NetworkMessage();
+                var msgType = new byte[8];
+                Array.Copy(rxMessage, 64, msgType, 0, 8);
+                var msgTypeString = Encoding.Unicode.GetString(msgType).Replace("\0", "");
+
+                var networkMsgProcessor = new NetworkMsgProcessor();
+                switch (msgTypeString)
+                {
+                    case "XXX":
+                        break;
+
+                    default:
+                        networkMessage.GetMessageFromStructure(rxMessage);
+                        if (networkMessage.MsgSender != "WTKST")
+                        {
+                            switch (networkMessage.MsgType)
+                            {
+                                case "STI":
+                                    {
+                                        if (networkMsgProcessor.ProcessMessage(rxMessage, 1) is NetworkMsgStatusInfo status)
+                                        {
+                                            // Check if the station already exists in the dictionary.
+                                            if (_availableStations.ContainsKey(status.StationID))
+                                            {
+                                                // Update the existing station's status.
+                                                _availableStations[status.StationID] = status;
+                                            }
+                                            else
+                                            {
+                                                // Add the new station to the dictionary and trigger the event for a station joining the network.
+                                                _availableStations[status.StationID] = status;
+                                                StationJoinedNetwork?.Invoke(this, status);
+                                            }
+                                        }
+                                        break;
+                                    }
+                                case "QSO":
+                                    {
+                                        if (networkMsgProcessor.ProcessMessage(rxMessage, 1) is DXQSO qso)
+                                        {
+                                            DXLogQsoReceived?.Invoke(this, qso);
+                                        }
+                                        break;
+                                    }
+                                case "SRP":
+                                    {
+                                        if (networkMsgProcessor.ProcessMessage(rxMessage, 1) is NetworkMsgSync message)
+                                        {
+                                            foreach (var qso in message.QSOs)
+                                            {
+                                                if (string.IsNullOrEmpty(qso.IDQSO) || qso.IDQSO == "0" || qso.IDQSO == "-1")
+                                                {
+                                                    return;
+                                                }
+                                                RequestQso(qso.IDQSO, qso.OriginStnID);
+                                            }
+                                        }
+                                        break;
+                                    }
+                            }
+                        }
+
+                        break;
+                }
+
+            }
+
+            catch
+            {
+
+            }
+        }
+
+
+
+    }
+}

--- a/WinTest/DXLog/DXLogNetworkClient.cs
+++ b/WinTest/DXLog/DXLogNetworkClient.cs
@@ -35,6 +35,7 @@ namespace WinTest.DXLog
                 _udpClient = new UdpClient();
                 _udpClient.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
                 _udpClient.Client.Bind(new IPEndPoint(IPAddress.Any, Port));
+                _udpClient.EnableBroadcast = true;
 
                 SendSyncRequest();
 
@@ -193,7 +194,7 @@ namespace WinTest.DXLog
                                             {
                                                 if (string.IsNullOrEmpty(qso.IDQSO) || qso.IDQSO == "0" || qso.IDQSO == "-1")
                                                 {
-                                                    return;
+                                                    continue;
                                                 }
                                                 RequestQso(qso.IDQSO, qso.OriginStnID);
                                             }

--- a/WinTest/DXLog/DXLogSync.cs
+++ b/WinTest/DXLog/DXLogSync.cs
@@ -1,0 +1,454 @@
+﻿//#define DEBUG_PACKET_LOSS
+
+using System;
+using System.Data;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Xml;
+using System.Xml.Serialization;
+using WinTest.DXLog;
+
+namespace WinTest.DXL
+{
+    /*
+     <?xml version="1.0"?>
+     <contactinfo>
+       	<logger>DXLog.net v2.6.9</logger>
+       	<qsoid>2</qsoid>
+       	<contestname>EUROPEAN-VHF</contestname>
+       	<timestamp>2024-10-16 08:45:30</timestamp>
+       	<mycall>M1DST</mycall>
+       	<band>144</band>
+       	<txfreq>14420000</txfreq>
+       	<operator/>
+       	<mode>CW</mode>
+       	<call>G4CLA</call>
+       	<countryprefix>G</countryprefix>
+       	<wpxprefix>G4</wpxprefix>
+       	<snt>599</snt>
+       	<rcv>599</rcv>
+       	<nr>1</nr>
+       	<exch1>282</exch1>
+       	<exch2>IO92JL</exch2>
+       	<exch3/>
+       	<exch4/>
+       	<xqso>False</xqso>
+       	<invalid>False</invalid>
+       	<duplicate>False</duplicate>
+       	<rule10broken>False</rule10broken>
+       	<azimuth>11</azimuth>
+       	<distance>138</distance>
+       	<stationid>STN1</stationid>
+       	<stationqso>2</stationqso>
+       	<stationtype>R</stationtype>
+       	<local>True</local>
+       	<mult1>IO92</mult1>
+       	<mult2/>
+       	<mult3/>
+       	<points>112</points>
+       	<period>1</period>
+       	<guid>53d3c3461ce1483bb9e4311d3eecc184</guid>
+       	<newqso>False</newqso>
+    </contactinfo>
+    */
+
+
+    [XmlRootAttribute("contactinfo", IsNullable = false)]
+    public class ContactInfo
+    {
+        public string logger;
+        public string contestname;
+
+        [XmlIgnore]
+        public DateTime timestamp { get; set; }
+
+        [XmlElement("timestamp")]
+        public string timestampString
+        {
+            get => timestamp.ToString("yyyy-MM-dd HH:mm:ss");
+            set => timestamp = DateTime.Parse(value);
+        }
+
+        public string mycall;
+        public string band;
+        public int txfreq;
+        [XmlElement(ElementName = "operator")]
+        public string op;
+        public string mode;
+        public string call;
+        public string countryprefix;
+        public string wpxprefix;
+        public string snt;
+        public string rcv;
+        public string nr;
+        public string exch1;
+        public string exch2;
+        public string exch3;
+        public string exch4;
+
+        [XmlIgnore]
+        public bool duplicate { get; set; }
+
+        [XmlIgnore]
+        public bool invalid { get; set; }
+
+        [XmlIgnore]
+        public bool rule10broken { get; set; }
+
+        [XmlIgnore]
+        public bool local { get; set; }
+
+        [XmlIgnore]
+        public bool newqso { get; set; }
+
+        [XmlElement("duplicate")]
+        public string duplicateString
+        {
+            get => duplicate.ToString();
+            set => duplicate = bool.Parse(value);
+        }
+
+        [XmlElement("stationid")]
+        public string stationname;
+
+        public string stationtype;
+        public string mult1;
+        public string mult2;
+        public string mult3;
+        public Guid guid;
+
+        public int points;
+        public int qsoid;
+        public int azimuth;
+        public int distance;
+        public int stationqso;
+        public int period;
+    }
+
+    public class DXLogListener
+    {
+        private volatile bool listen;
+        private UdpClient udpClient;
+
+        private void serializer_UnknownNode(object sender, XmlNodeEventArgs e)
+        {
+            Console.WriteLine("Unknown Node:" + e.Name + "\t" + e.Text);
+        }
+
+        private void serializer_UnknownAttribute
+        (object sender, XmlAttributeEventArgs e)
+        {
+            System.Xml.XmlAttribute attr = e.Attr;
+            Console.WriteLine("Unknown attribute " +
+            attr.Name + "='" + attr.Value + "'");
+        }
+
+        public DXLogListener(int udpPort)
+        {
+            var ep = new IPEndPoint(IPAddress.Any, udpPort);
+            udpClient = new UdpClient();
+            udpClient.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, 1);
+            udpClient.Client.Bind(ep);
+            listen = true;
+
+            var listener = new Thread(() =>
+            {
+                while (listen)
+                {
+                    try
+                    {
+                        byte[] data = udpClient.Receive(ref ep);
+                        if (data.Length > 0)
+                        {
+                            var ustream = new System.IO.MemoryStream(data);
+
+                            XmlSerializer serializer = new XmlSerializer(typeof(ContactInfo));
+                            /* If the XML document has been altered with unknown
+                            nodes or attributes, handle them with the
+                            UnknownNode and UnknownAttribute events.*/
+                            serializer.UnknownNode += new XmlNodeEventHandler(serializer_UnknownNode);
+                            serializer.UnknownAttribute += new XmlAttributeEventHandler(serializer_UnknownAttribute);
+
+                            ContactInfo ci;
+                            /* Use the Deserialize method to restore the object's state with
+                            data from the XML document. */
+                            ci = (ContactInfo)serializer.Deserialize(ustream);
+                            // Read the order date.
+                            Console.WriteLine("call: " + ci.call);
+
+                            //Console.WriteLine("WT Msg " + Msg.Msg + " src " + Msg.Src + " dest " + Msg.Dst + " data " + Msg.Data + " checksum " + Msg.HasChecksum);
+                            DXLogMessageReceived?.Invoke(this, new DXLogMessageEventArgs(ci));
+                        }
+                    }
+                    catch (SocketException)
+                    {
+                        break; // exit the while loop
+                    }
+                }
+                //Console.WriteLine("listener done");
+            });
+            listener.IsBackground = true;
+            listener.Start();
+        }
+
+        public event EventHandler<DXLogMessageEventArgs> DXLogMessageReceived;
+        public class DXLogMessageEventArgs : EventArgs
+        {
+            /// <summary>
+            /// Win-Test message
+            /// </summary>
+            public DXLogMessageEventArgs(ContactInfo ci)
+            {
+                this.ci = ci;
+            }
+            public ContactInfo ci { get; private set; }
+        }
+
+        public void close()
+        {
+            listen = false;
+
+            udpClient.Client.Shutdown(SocketShutdown.Both);
+            udpClient.Close();
+        }
+    }
+
+    public class DXLogSync : WinTestLogBase
+    {
+        private DXLogListener qtl;
+        private DXLogNetworkClient _networkClient;
+
+        public DXLogSync(LogWriteMessageDelegate mylog) : base(mylog)
+        {
+
+            QSO.Columns.Add("TXNR");
+            DataColumn[] QSOkeys = new DataColumn[]
+            {
+                QSO.Columns["TXNR"],
+                QSO.Columns["BAND"]
+            };
+            QSO.PrimaryKey = QSOkeys;
+        }
+
+        public override void Dispose()
+        {
+            if (qtl != null)
+                qtl.close();
+
+            _networkClient?.StopListening();
+        }
+
+
+        public override string getStatus()
+        {
+            return QSO.Rows.Count.ToString();
+        }
+
+        public override void Get_QSOs(string wtname)
+        {
+            // start listener
+            if (qtl == null)
+            {
+                QSO.Clear();
+                qtl = new DXLogListener(12060); // DXLog default UDP port
+                qtl.DXLogMessageReceived += DXLogMessageReceivedHandler;
+            }
+
+            if (_networkClient == null)
+            {
+                _networkClient = new DXLogNetworkClient();
+                _networkClient.DXLogQsoReceived += _networkClient_DXLogQsoReceived;
+                _networkClient.StationJoinedNetwork += _networkClient_StationJoinedNetwork; ;
+                _networkClient.StationLeftNetwork += _networkClient_StationLeftNetwork;
+                _ = _networkClient.StartListeningAsync();
+            }
+
+        }
+
+        private void _networkClient_StationLeftNetwork(object sender, string e)
+        {
+            Console.WriteLine($"DXLog client left : {e}");
+        }
+
+        private void _networkClient_StationJoinedNetwork(object sender, NetworkMsgStatusInfo e)
+        {
+            Console.WriteLine($"DXLog client joined : {e.StationID} on {e.Band}");
+        }
+
+        /// <summary>
+        /// This is fired every time a QSO is received as part of a sync request.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void _networkClient_DXLogQsoReceived(object sender, DXQSO e)
+        {
+            // QSO ContactInfo received
+            var row = QSO.NewRow();
+            row["CALL"] = e.Callsign;
+
+            switch (e.Band)
+            {
+                case "50":
+                    row["BAND"] = "50M";
+                    break;
+                case "70":
+                    row["BAND"] = "70M";
+                    break;
+                case "144":
+                    row["BAND"] = "144M";
+                    break;
+                case "432":
+                    row["BAND"] = "432M";
+                    break;
+                case "1296":
+                    row["BAND"] = "1_2G";
+                    break;
+                case "2320":
+                    row["BAND"] = "2_3G";
+                    break;
+                case "3400":
+                    row["BAND"] = "3_4G";
+                    break;
+                case "5700":
+                    row["BAND"] = "5_7G";
+                    break;
+                case "10G":
+                    row["BAND"] = "10G";
+                    break;
+                case "24G":
+                    row["BAND"] = "24G";
+                    break;
+                case "47G":
+                    row["BAND"] = "47G";
+                    break;
+                case "76G":
+                    row["BAND"] = "76G";
+                    break;
+                default:
+                    row["BAND"] = "";
+                    break;
+            }
+
+            row["TIME"] = e.TimeStamp.ToString("HH:mm");
+            row["TXNR"] = e.Nr;
+            row["SENT"] = $"{e.Sent} {e.Nr}";
+            row["RCVD"] = $"{e.Rcvd}";
+            row["LOC"] = e.RecInfo;
+
+            try
+            {
+                var key = new object[] { row["TXNR"], row["BAND"] };
+                var qso = QSO.Rows.Find(key);
+                if (qso != null)
+                {
+                    // Update only if necessary fields differ
+                    if (!qso["CALL"].Equals(row["CALL"]) || !qso["TIME"].Equals(row["TIME"]) || !qso["SENT"].Equals(row["SENT"]) || !qso["RCVD"].Equals(row["RCVD"]) || !qso["LOC"].Equals(row["LOC"]))
+                    {
+                        qso["CALL"] = row["CALL"];
+                        qso["TIME"] = row["TIME"];
+                        qso["SENT"] = row["SENT"];
+                        qso["RCVD"] = row["RCVD"];
+                        qso["LOC"] = row["LOC"];
+                    }
+                }
+                else
+                {
+                    QSO.Rows.Add(row);
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error processing QSO: {ex.Message}\n{ex.StackTrace}");
+            }
+
+        }
+
+        /// <summary>
+        /// This is fired due to a normal QSO broadcast.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void DXLogMessageReceivedHandler(object sender, DXLogListener.DXLogMessageEventArgs e)
+        {
+            // QSO ContactInfo received
+            DataRow row = QSO.NewRow();
+            row["CALL"] = e.ci.call;
+
+            switch (e.ci.band)
+            {
+                case "50":
+                    row["BAND"] = "50M";
+                    break;
+                case "70":
+                    row["BAND"] = "70M";
+                    break;
+                case "144":
+                    row["BAND"] = "144M";
+                    break;
+                case "432":
+                    row["BAND"] = "432M";
+                    break;
+                case "1296":
+                    row["BAND"] = "1_2G";
+                    break;
+                case "2320":
+                    row["BAND"] = "2_3G";
+                    break;
+                case "3400":
+                    row["BAND"] = "3_4G";
+                    break;
+                case "5700":
+                    row["BAND"] = "5_7G";
+                    break;
+                case "10G":
+                    row["BAND"] = "10G";
+                    break;
+                case "24G":
+                    row["BAND"] = "24G";
+                    break;
+                case "47G":
+                    row["BAND"] = "47G";
+                    break;
+                case "76G":
+                    row["BAND"] = "76G";
+                    break;
+                default:
+                    row["BAND"] = "";
+                    break;
+            }
+
+            row["TIME"] = e.ci.timestamp.ToString("HH:mm"); // FIXME warum nicht als object? So fehlt das Datum
+            uint serial_sent = UInt32.Parse(e.ci.nr);
+            row["TXNR"] = e.ci.nr;
+            row["SENT"] = e.ci.snt + serial_sent.ToString("D3");
+            row["RCVD"] = e.ci.rcv + e.ci.exch1;
+            row["LOC"] = e.ci.exch2;
+            try
+            {
+                var qso = QSO.Rows.Find(new object[]
+                {
+                                row["TXNR"],
+                                row["BAND"]
+                });
+
+                if (qso != null)
+                {
+                    if (!(qso.ItemArray.SequenceEqual(row.ItemArray)))
+                    {
+                        qso.Delete();
+                        QSO.Rows.Add(row);
+                    }
+                }
+                else
+                {
+                    QSO.Rows.Add(row);
+                }
+
+            }
+            catch (Exception ex) { Console.WriteLine(ex.Message); }
+        }
+    }
+
+}

--- a/WinTest/DXLog/DXLogSync.cs
+++ b/WinTest/DXLog/DXLogSync.cs
@@ -305,13 +305,13 @@ namespace WinTest.DXL
                 case "1296":
                     row["BAND"] = "1_2G";
                     break;
-                case "2320":
+                case "2300":
                     row["BAND"] = "2_3G";
                     break;
                 case "3400":
                     row["BAND"] = "3_4G";
                     break;
-                case "5700":
+                case "5650":
                     row["BAND"] = "5_7G";
                     break;
                 case "10G":

--- a/WinTest/DXLog/DXQSO.cs
+++ b/WinTest/DXLog/DXQSO.cs
@@ -1,0 +1,176 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace WinTest.DXLog
+{
+    public class DXQSO
+    {
+        // Properties
+        public int IDQSO => _idqso;
+
+        public string Band => _band;
+
+        public int Period => _period;
+
+        public decimal Frequency => _frequency;
+
+        public string Mode => _mode;
+
+        public DateTime QSOTime => _qsoTime;
+
+        public string Callsign => _callsign;
+
+        public string Sent => _sent;
+
+        public int Nr => _nr;
+
+        public string Rcvd => _rcvd;
+
+        public string RecInfo => _recInfo;
+
+        public string RecInfo2 => _recInfo2;
+
+        public string RecInfo3 => _recInfo3;
+
+        public string Stn => _stn;
+
+        public string OriginStnID => _originStnId;
+
+        public int OriginIDQSO => _originIdqso;
+
+        public DateTime TimeStamp => _timeStamp;
+
+        public string Operator => _operator;
+
+        public bool XQSO => _xqso;
+
+        public Guid QSOGuid => _qsoGuid;
+
+
+        // The following code converts a DXQSO to and from a buffer which
+        // can be sent across the network.
+
+        // VERY IMPORTANT: There are applications that rely on the exact format of QSO network
+        // messages. Most notable is Clublog's Livestream gateway. Extending the message will
+        // probably not break any other applications but changing the location of e.g., Operator, will.
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        private struct StructQSO
+        {
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 6)]
+            public byte[] IDQSO;
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 10)]
+            public byte[] Band;
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 3)]
+            public byte[] Period;
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 15)]
+            public byte[] Frequency;
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 10)]
+            public byte[] Mode;
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 15)]
+            public byte[] QSOTime;
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
+            public byte[] Callsign;
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 5)]
+            public byte[] Sent;
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 6)]
+            public byte[] Nr;
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 20)]
+            public byte[] Rcvd;
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 20)]
+            public byte[] RecInfo;
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 20)]
+            public byte[] RecInfo2;
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 20)]
+            public byte[] RecInfo3;
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 15)]
+            public byte[] Stn;
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 15)]
+            public byte[] OriginStnID;
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 6)]
+            public byte[] OriginIDQSO;
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 15)]
+            public byte[] Timestamp;
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
+            public byte[] QSOGuid;
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 20)]
+            public byte[] Operator;
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 1)]
+            public byte[] XQSO;
+        }
+
+        private int StructSize = 254;
+        private int _idqso;
+        private string _band;
+        private int _period;
+        private decimal _frequency;
+        private string _mode;
+        private DateTime _qsoTime;
+        private string _callsign;
+        private string _sent;
+        private int _nr;
+        private string _rcvd;
+        private string _recInfo;
+        private string _recInfo2;
+        private string _recInfo3;
+        private string _stn;
+        private string _originStnId;
+        private int _originIdqso;
+        private DateTime _timeStamp;
+        private string _operator;
+        private bool _xqso;
+        private Guid _qsoGuid;
+
+        public void GetHeaderFromStructure(byte[] inBuffer)
+        {
+            byte[] buffer = new byte[StructSize];
+            Array.Copy(inBuffer, 0, buffer, 0, StructSize);
+            GCHandle handle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+            StructQSO structQSO = (StructQSO)Marshal.PtrToStructure(handle.AddrOfPinnedObject(), typeof(StructQSO));
+            handle.Free();
+
+            int.TryParse(GetString(structQSO.IDQSO), out _idqso);
+            int.TryParse(GetString(structQSO.Period), out _period);
+            _band = GetString(structQSO.Band);
+            decimal.TryParse(GetString(structQSO.Frequency), System.Globalization.NumberStyles.Any,
+                System.Globalization.CultureInfo.GetCultureInfo("en-US"), out _frequency);
+            _mode = GetString(structQSO.Mode);
+            _qsoTime = GetDTFromUnixTime(double.Parse(GetString(structQSO.QSOTime)));
+            _callsign = GetString(structQSO.Callsign);
+            _sent = GetString(structQSO.Sent);
+            int.TryParse(GetString(structQSO.Nr), out _nr);
+            _rcvd = GetString(structQSO.Rcvd);
+            _recInfo = GetString(structQSO.RecInfo);
+            _recInfo2 = GetString(structQSO.RecInfo2);
+            _recInfo3 = GetString(structQSO.RecInfo3);
+            _stn = GetString(structQSO.Stn);
+            int.TryParse(GetString(structQSO.OriginIDQSO), out _originIdqso);
+            _originStnId = GetString(structQSO.OriginStnID);
+
+            if (double.TryParse(GetString(structQSO.Timestamp), out double ts))
+            {
+                _timeStamp = GetDTFromUnixTime(ts);
+            }
+
+            try
+            {
+                _qsoGuid = new Guid(structQSO.QSOGuid);
+            }
+            catch { }
+
+            _operator = GetString(structQSO.Operator);
+            _xqso = GetString(structQSO.XQSO) == "Y";
+        }
+
+        private string GetString(byte[] bytes)
+        {
+            return System.Text.Encoding.UTF8.GetString(bytes).Trim('\0');
+        }
+
+        private DateTime GetDTFromUnixTime(double unixTime)
+        {
+            var dt = new DateTime(1970, 1, 1, 0, 0, 0, 0);
+            return dt.AddSeconds(unixTime);
+        }
+    }
+}

--- a/WinTest/DXLog/NetworkMessage.cs
+++ b/WinTest/DXLog/NetworkMessage.cs
@@ -1,0 +1,97 @@
+﻿using System.Runtime.InteropServices;
+
+namespace WinTest.DXLog
+{
+    public class NetworkMessage
+    {
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        public struct StructNetworkMsg
+        {
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
+            public char[] MsgSender;
+            
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
+            public char[] MsgDestination;
+            
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 4)]
+            public char[] MsgType;
+            
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 4)]
+            public char[] MsgID;
+            
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 500)]
+            public byte[] MsgData;
+        }
+
+        public int StructSize = 580;
+        public string MsgSender;
+        public string MsgDestination;
+        public string MsgType;
+        public string MsgID;
+        public byte[] MsgData;
+
+        private StructNetworkMsg _networkMessage;
+        
+        private void CreateStruct()
+        {
+            _networkMessage = new StructNetworkMsg
+            {
+                MsgSender = PadString(MsgSender, 16).ToCharArray(),
+                MsgDestination = PadString(MsgDestination, 16).ToCharArray(),
+                MsgType = PadString(MsgType, 4).ToCharArray(),
+                MsgID = PadString(MsgID, 4).ToCharArray(),
+                MsgData = MsgData
+            };
+        }
+        
+        private void GetValuesFromStruct()
+        {
+            MsgSender = TrimString(_networkMessage.MsgSender);
+            MsgDestination = TrimString(_networkMessage.MsgDestination);
+            MsgType = TrimString(_networkMessage.MsgType);
+            MsgID = TrimString(_networkMessage.MsgID);
+            MsgData = _networkMessage.MsgData;
+        }
+        
+        public byte[] ToByteArray()
+        {
+            CreateStruct();
+            
+            var buffer = new byte[StructSize];
+            var h = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+            try
+            {
+                Marshal.StructureToPtr(_networkMessage, h.AddrOfPinnedObject(), false);
+            }
+            finally
+            {
+                h.Free();
+            }
+            return buffer;
+        }
+        
+        public void GetMessageFromStructure(byte[] buffer)
+        {
+            var handle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+            try
+            {
+                _networkMessage = (StructNetworkMsg)Marshal.PtrToStructure(handle.AddrOfPinnedObject(), typeof(StructNetworkMsg));
+                GetValuesFromStruct();
+            }
+            finally
+            {
+                handle.Free();
+            }
+        }
+        
+        private string PadString(string input, int length)
+        {
+            return input.PadRight(length, '\0');
+        }
+        
+        private string TrimString(char[] input)
+        {
+            return new string(input).TrimEnd('\0');
+        }
+    }
+}

--- a/WinTest/DXLog/NetworkMsgProcessor.cs
+++ b/WinTest/DXLog/NetworkMsgProcessor.cs
@@ -1,0 +1,45 @@
+﻿namespace WinTest.DXLog
+{
+    public class NetworkMsgProcessor
+    {
+        public object ProcessMessage(byte[] rxData, int msgSize)
+        {
+            switch (msgSize)
+            {
+                case 0:
+                    //        SMALL
+                    //        NetworkSmallMessage s_msg = new();
+                    //        s_msg.GetMessageFromStructure(rxData);
+                    //        return s_msg.MsgType switch { _ => null };
+                    return null;
+                
+                default:
+                    var msg = new NetworkMessage();
+                    msg.GetMessageFromStructure(rxData);
+                    switch (msg.MsgType)
+                    {
+                        case "STI":
+                            var statusInfo = new NetworkMsgStatusInfo();
+                            statusInfo.GetHeaderFromStructure(msg.MsgData);
+                            return statusInfo;
+
+                        case "QSO":
+                            var qso = new DXQSO();
+                            qso.GetHeaderFromStructure(msg.MsgData);
+                            return qso;
+
+                        case "SRP": // Result is ignored
+                        case "SSQ": // Result is ignored
+                            var msg_srp = new NetworkMsgSync();
+                            msg_srp.GetHeaderFromStructure(msg.MsgData);
+                            return msg_srp;
+                    }
+
+                    return null;
+
+            }
+
+        }
+
+    }
+}

--- a/WinTest/DXLog/NetworkMsgSked.cs
+++ b/WinTest/DXLog/NetworkMsgSked.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace WinTest.DXLog
+{
+    public class NetworkMsgSked
+    {
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        public struct Sked
+        {
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
+            public byte[] Callsign;
+
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 15)]
+            public byte[] SkedTime;
+
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 15)]
+            public byte[] Frequency;
+
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 10)]
+            public byte[] Mode;
+
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 75)]
+            public byte[] Comments;
+
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 2)]
+            public byte[] IsDeleted;
+        }
+
+        public int StructSize = 500;
+
+        public string Callsign;
+        public DateTime SkedTime;
+        public string Frequency;
+        public string Mode;
+        public string Comments;
+        public string IsDeleted;
+
+        private Sked _sked;
+
+        private string GetUnixTime(DateTime inTime)
+        {
+            var span = (inTime - new DateTime(1970, 1, 1, 0, 0, 0, 0));
+            return ((long)span.TotalSeconds).ToString();
+        }
+
+        private DateTime GetDtFromUnixTime(double unixTime)
+        {
+            var dt = new DateTime(1970, 1, 1, 0, 0, 0, 0);
+            return dt.AddSeconds(unixTime);
+        }
+
+        private void CreateStruct()
+        {
+            _sked = new Sked
+            {
+                Callsign = GetBytes(Callsign ?? "", 16),
+                SkedTime = GetBytes(GetUnixTime(SkedTime), 15),
+                Frequency = GetBytes(Frequency ?? "", 15),
+                Mode = GetBytes(Mode ?? "", 10),
+                Comments = GetBytes(Comments ?? "", 75),
+                IsDeleted = GetBytes(IsDeleted ?? "N", 2)
+            };
+        }
+
+        private void GetValuesFromStruct()
+        {
+            Callsign = GetString(_sked.Callsign);
+            SkedTime = GetDtFromUnixTime(double.Parse(GetString(_sked.SkedTime)));
+            Frequency = GetString(_sked.Frequency);
+            Mode = GetString(_sked.Mode);
+            Comments = GetString(_sked.Comments);
+            IsDeleted = GetString(_sked.IsDeleted);
+        }
+
+        public byte[] ToByteArray()
+        {
+            CreateStruct();
+
+            try
+            {
+                var buffer = new byte[StructSize];
+                var h = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+                Marshal.StructureToPtr(_sked, h.AddrOfPinnedObject(), false);
+                h.Free();
+                return buffer;
+            }
+            catch (Exception ex)
+            {
+                throw ex;
+            }
+        }
+
+        public void GetHeaderFromStructure(byte[] buffer)
+        {
+            try
+            {
+                var handle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+                _sked = (Sked)Marshal.PtrToStructure(handle.AddrOfPinnedObject(), typeof(Sked));
+                handle.Free();
+                GetValuesFromStruct();
+            }
+            catch (Exception ex)
+            {
+                throw ex;
+            }
+        }
+
+        private byte[] GetBytes(string str, int size)
+        {
+            var bytes = new byte[size];
+            Encoding.UTF8.GetBytes(str, 0, str.Length > size ? size : str.Length, bytes, 0);
+            return bytes;
+        }
+
+        private string GetString(byte[] bytes)
+        {
+            return Encoding.UTF8.GetString(bytes).Trim('\0');
+        }
+    }
+}

--- a/WinTest/DXLog/NetworkMsgStatusInfo.cs
+++ b/WinTest/DXLog/NetworkMsgStatusInfo.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Globalization;
+using System.Runtime.InteropServices;
+
+namespace WinTest.DXLog
+{
+    public class NetworkMsgStatusInfo
+    {
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        public struct StructStatusInfo
+        {
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 16)]
+            public string StationID;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 10)]
+            public string Band;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 10)]
+            public string Mode;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 5)]
+            public string StationType;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 20)]
+            public string QSYFreq;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 20)]
+            public string Radio1Freq;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 20)]
+            public string Radio2Freq;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 50)]
+            public string LoggedOp;
+
+        }
+
+        public int StructSize = 500;
+
+        public string StationID;
+        public string Band;
+        public string Mode;
+        public string StationType;
+        public double QSYFreq;
+        public double Radio1Freq;
+        public double Radio2Freq;
+        public string LoggedOp;
+        public DateTime LastSeenUtc;
+
+        public StructStatusInfo _statusInfo;
+
+        public void CreateStruct()
+        {
+            _statusInfo = new StructStatusInfo
+            {
+                StationID = StationID,
+                Band = Band,
+                Mode = Mode,
+                StationType = StationType,
+                QSYFreq = QSYFreq.ToString(CultureInfo.InvariantCulture),
+                Radio1Freq = Radio1Freq.ToString(CultureInfo.InvariantCulture),
+                Radio2Freq = Radio2Freq.ToString(CultureInfo.InvariantCulture),
+                LoggedOp = LoggedOp
+            };
+        }
+
+        private void GetValuesFromStruct()
+        {
+            StationID = _statusInfo.StationID;
+            Band = _statusInfo.Band;
+            Mode = _statusInfo.Mode;
+            StationType = _statusInfo.StationType;
+            QSYFreq = Convert.ToDouble(_statusInfo.QSYFreq);
+            Radio1Freq = Convert.ToDouble(_statusInfo.Radio1Freq);
+            Radio2Freq = Convert.ToDouble(_statusInfo.Radio2Freq);
+            LoggedOp = _statusInfo.LoggedOp;
+            LastSeenUtc = DateTime.UtcNow;
+        }
+
+        public byte[] StructToByteArray(object _oStruct)
+        {
+            try
+            {
+                var buffer = new byte[StructSize];
+                var h = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+                Marshal.StructureToPtr(_oStruct, h.AddrOfPinnedObject(), false);
+                h.Free();
+                return buffer;
+            }
+            catch (Exception ex)
+            {
+                throw ex;
+            }
+        }
+
+        public void GetHeaderFromStructure(byte[] buffer)
+        {
+            try
+            {
+                var handle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+                _statusInfo = (StructStatusInfo)Marshal.PtrToStructure(handle.AddrOfPinnedObject(), typeof(StructStatusInfo));
+                handle.Free();
+                GetValuesFromStruct();
+            }
+            catch (Exception ex)
+            {
+                throw ex;
+            }
+        }
+    }
+}

--- a/WinTest/DXLog/NetworkMsgSync.cs
+++ b/WinTest/DXLog/NetworkMsgSync.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace WinTest.DXLog
+{
+    public class NetworkMsgSync
+    {
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        public struct Sync
+        {
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 5)]
+            public SyncQSODesc[] QSODesc;
+        }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        public struct SyncQSODesc
+        {
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 6)]
+            public string IDQSO;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 6)]
+            public string SynchPhase;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 15)]
+            public string OriginStnID;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 6)]
+            public string OriginIDQSO;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 15)]
+            public string Timestamp;
+        }
+
+        private const int StructSize = 500;
+
+        public SyncQSODesc[] QSOs = new SyncQSODesc[5];
+
+        private Sync _sync;
+
+        public void CreateStruct()
+        {
+            _sync = new Sync
+            {
+                QSODesc = QSOs
+            };
+        }
+
+        private void GetValuesFromStruct()
+        {
+            QSOs = _sync.QSODesc;
+        }
+
+        public byte[] ToByteArray()
+        {
+            CreateStruct();
+
+            try
+            {
+                var buffer = new byte[StructSize];
+                var h = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+                Marshal.StructureToPtr(_sync, h.AddrOfPinnedObject(), false);
+                h.Free();
+                return buffer;
+            }
+            catch (Exception ex)
+            {
+                throw ex;
+            }
+        }
+
+        public void GetHeaderFromStructure(byte[] buffer)
+        {
+            try
+            {
+                var handle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+                _sync = (Sync)Marshal.PtrToStructure(handle.AddrOfPinnedObject(), typeof(Sync));
+                handle.Free();
+                GetValuesFromStruct();
+            }
+            catch (Exception ex)
+            {
+                throw ex;
+            }
+        }
+
+
+    }
+}

--- a/WinTest/DXLog/NetworkMsgSyncRequest.cs
+++ b/WinTest/DXLog/NetworkMsgSyncRequest.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace WinTest.DXLog
+{
+    public class NetworkMsgSyncRequest
+    {
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        public struct SyncRequest
+        {
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 6)]
+            public string IDQSO;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 6)]
+            public string SynchPhase;
+        }
+
+        public int StructSize = 500;
+
+        public string IDQSO;
+        public int SyncPhase;
+
+        private SyncRequest _syncRequest;
+
+        public void CreateStruct()
+        {
+            _syncRequest = new SyncRequest
+            {
+                IDQSO = IDQSO,
+                SynchPhase = SyncPhase.ToString()
+            };
+        }
+
+        private void GetValuesFromStruct()
+        {
+            IDQSO = _syncRequest.IDQSO;
+            int.TryParse(_syncRequest.SynchPhase, out SyncPhase);
+        }
+
+        public byte[] ToByteArray()
+        {
+            CreateStruct();
+
+            try
+            {
+                var buffer = new byte[StructSize];
+                var h = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+                Marshal.StructureToPtr(_syncRequest, h.AddrOfPinnedObject(), false);
+                h.Free();
+                return buffer;
+            }
+            catch (Exception ex)
+            {
+                throw ex;
+            }
+        }
+
+        public void GetHeaderFromStructure(byte[] buffer)
+        {
+            try
+            {
+                var handle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+                _syncRequest = (SyncRequest)Marshal.PtrToStructure(handle.AddrOfPinnedObject(), typeof(SyncRequest));
+                handle.Free();
+                GetValuesFromStruct();
+            }
+            catch (Exception ex)
+            {
+                throw ex;
+            }
+        }
+
+
+    }
+}

--- a/WinTest/WinTest.csproj
+++ b/WinTest/WinTest.csproj
@@ -43,6 +43,15 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DXLog\DXQSO.cs" />
+    <Compile Include="DXLog\DXLogNetworkClient.cs" />
+    <Compile Include="DXLog\DXLogSync.cs" />
+    <Compile Include="DXLog\NetworkMessage.cs" />
+    <Compile Include="DXLog\NetworkMsgProcessor.cs" />
+    <Compile Include="DXLog\NetworkMsgSked.cs" />
+    <Compile Include="DXLog\NetworkMsgStatusInfo.cs" />
+    <Compile Include="DXLog\NetworkMsgSync.cs" />
+    <Compile Include="DXLog\NetworkMsgSyncRequest.cs" />
     <Compile Include="QARTestLogSync.cs" />
     <Compile Include="WinTestLog.cs" />
     <Compile Include="WinTestLogBase.cs" />

--- a/app.config
+++ b/app.config
@@ -249,6 +249,9 @@
          <setting name="WS_API_URL" serializeAs="String">
             <value>https://www.airscout.app/airscout/api/v1</value>
          </setting>
-      </wtKST.Properties.Settings>
+         <setting name="DXLog_Sync_active" serializeAs="String">
+            <value>False</value>
+         </setting>
+       </wtKST.Properties.Settings>
    </userSettings>
 </configuration>

--- a/wtKST/MainDlg.cs
+++ b/wtKST/MainDlg.cs
@@ -138,6 +138,7 @@ namespace wtKST
         private System.Windows.Forms.Timer ti_Reconnect;
         private System.Windows.Forms.Timer ti_ToolTip_active;
         private System.Windows.Forms.Timer ti_N1MM;
+        private System.Windows.Forms.Timer ti_BandRefresh;
 
         private System.Windows.Forms.ToolTip tt_Info;
         private System.Windows.Forms.ToolTip tt_ASInfo;
@@ -288,6 +289,7 @@ namespace wtKST
 
             // handle Log interface
             init_wtQSO();
+            ti_BandRefresh.Start();
 
             UpdateUserBandsWidth();
             AS_if = new wtKST.AirScoutInterface();
@@ -1471,6 +1473,7 @@ namespace wtKST
                                 wtQSO_local_lock = false;
 
                                 Check_QSOs();
+                                UpdateLogTooltip();
                             }
                             catch
                             {
@@ -1517,6 +1520,15 @@ namespace wtKST
             }
             ti_N1MM.Interval = Math.Max(1000, Settings.Default.N1MM_UpdateInterval * 1000);
             ti_N1MM.Start();
+        }
+
+        private void ti_BandRefresh_Tick(object sender, EventArgs e)
+        {
+            if (KST.State == KSTcom.KST_STATE.Connected && wtQSO != null && !wtQSO_local_lock)
+            {
+                Check_QSOs();
+                UpdateLogTooltip();
+            }
         }
 
         public void Say(string Text)
@@ -3255,6 +3267,7 @@ namespace wtKST
             this.tt_ASInfo = new System.Windows.Forms.ToolTip(this.components);
             this.ti_UpdateFilter = new System.Windows.Forms.Timer(this.components);
             this.ti_N1MM = new System.Windows.Forms.Timer(this.components);
+            this.ti_BandRefresh = new System.Windows.Forms.Timer(this.components);
             this.cmn_userlist = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.cmn_userlist_wtsked = new System.Windows.Forms.ToolStripMenuItem();
             this.cmn_userlist_chatReview = new System.Windows.Forms.ToolStripMenuItem();
@@ -3934,6 +3947,11 @@ namespace wtKST
             //
             this.ti_N1MM.Interval = 10000;
             this.ti_N1MM.Tick += new System.EventHandler(this.ti_N1MM_Tick);
+            //
+            // ti_BandRefresh
+            //
+            this.ti_BandRefresh.Interval = 5000;
+            this.ti_BandRefresh.Tick += new System.EventHandler(this.ti_BandRefresh_Tick);
             // 
             // cmn_userlist
             // 

--- a/wtKST/MainDlg.cs
+++ b/wtKST/MainDlg.cs
@@ -6,12 +6,16 @@ using System.Drawing;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Net.Sockets;
 using System.Net;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Runtime.Remoting.Messaging;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using WinTest;
+using WinTest.DXL;
+using WinTest.DXLog;
 using wtKST.Properties;
 using Application = System.Windows.Forms.Application;
 
@@ -182,6 +186,7 @@ namespace wtKST
         private ToolStripStatusLabel tsl_LED_AS_Status;
         private ToolStripStatusLabel tsl_LED_Log_Status;
         private ToolStripStatusLabel tsl_LED_KST_Status;
+        private ToolStripMenuItem skedTestToolStripMenuItem;
         private string AS_watchlist = "";
 
         public MainDlg()
@@ -1297,6 +1302,30 @@ namespace wtKST
                 ti_N1MM.Interval = Math.Max(1000, Settings.Default.N1MM_UpdateInterval * 1000);
                 ti_N1MM.Start();
             }
+            else if (Settings.Default.DXLog_Sync_active)
+            {
+                if (wtQSO != null)
+                {
+                    if (wtQSO.GetType() == typeof(DXLogSync))
+                    {
+                        Console.WriteLine("wtQSO already DXLogSync");
+                        return;
+                    }
+                    else
+                    {
+                        Console.WriteLine("wtQSO active " + wtQSO.GetType().ToString());
+                        ((IDisposable)wtQSO).Dispose();
+                        wtQSO = null;
+                    }
+                }
+                wtQSO = new DXLogSync(MainDlg.Log.WriteMessage);
+                if (wts != null)
+                {
+                    Console.WriteLine("wts active - turn off");
+                    wts = null;
+                }
+                wtQSO.LogStateChanged += Log_StateChanged;
+            }
             else
             {
                 ti_N1MM.Stop();
@@ -1431,6 +1460,8 @@ namespace wtKST
                                 else if (wtQSO.GetType() == typeof(WtLogSync))
                                     wtQSO.Get_QSOs(Settings.Default.WinTest_StationName);
                                 else if (wtQSO.GetType() == typeof(QARTestLogSync))
+                                    wtQSO.Get_QSOs("");
+                                else if (wtQSO.GetType() == typeof(DXLogSync))
                                     wtQSO.Get_QSOs("");
                                 if (!String.IsNullOrEmpty(wtQSO.MyLoc) && WCCheck.WCCheck.IsLoc(wtQSO.MyLoc) > 0 && !wtQSO.MyLoc.Equals(Settings.Default.KST_Loc))
                                 {
@@ -2855,27 +2886,32 @@ namespace wtKST
 
         private void cmn_item_wtsked_Click(object sender, EventArgs e)
         {
-            ToolStripItem clickedItem = sender as ToolStripItem;
-            string call = cmn_userlist_get_call_from_contextMenu(clickedItem.Owner as ContextMenuStrip);
-
-            if (!String.IsNullOrEmpty(call))
+            if (sender is ToolStripItem clickedItem)
             {
-                string notes = "KST - Offline";
-                DataRow findrow = CALL.Rows.Find(call);
-                // [JO02OB - 113\\260] AP in 2min
-                if (findrow != null)
-                    notes = String.Format("[{0} - {1}°]", findrow["LOC"].ToString(), findrow["DIR"].ToString());
-                wtskdlg = new WTSkedDlg(WCCheck.WCCheck.SanitizeCall(call), wts.wtStatusList, new BindingList<bandinfo>(selected_bands()),
-                                        notes, last_sked_qrg, kst_sked_qrg, kst_sked_mode, kst_sked_band_freq);
-                if (wtskdlg.ShowDialog() == DialogResult.OK)
-                {
-                    WinTest.wtSked wtsked = new WinTest.wtSked();
+                var call = cmn_userlist_get_call_from_contextMenu(clickedItem.Owner as ContextMenuStrip);
 
-                    wtsked.send_locksked(wtskdlg.target_wt);
-                    last_sked_qrg = wtskdlg.qrg;
-                    wtsked.send_addsked(wtskdlg.target_wt, wtskdlg.sked_time, wtskdlg.qrg, wtskdlg.band, wtskdlg.mode,
-                        wtskdlg.call, wtskdlg.notes);
-                    wtsked.send_unlocksked(wtskdlg.target_wt);
+                if (!String.IsNullOrEmpty(call))
+                {
+                    var notes = "KST - Offline";
+                    var dataRow = CALL.Rows.Find(call);
+                    // [JO02OB - 113\\260] AP in 2min
+                    if (dataRow != null)
+                    {
+                        notes = $"[{dataRow["LOC"]} - {dataRow["DIR"]}°]";
+                    }
+
+                    wtskdlg = new WTSkedDlg(WCCheck.WCCheck.SanitizeCall(call), wts.wtStatusList, new BindingList<bandinfo>(selected_bands()),
+                        notes, last_sked_qrg, kst_sked_qrg, kst_sked_mode, kst_sked_band_freq);
+                
+                    if (wtskdlg.ShowDialog() == DialogResult.OK)
+                    {
+                        var wtSked = new wtSked();
+
+                        wtSked.send_locksked(wtskdlg.target_wt);
+                        last_sked_qrg = wtskdlg.qrg;
+                        wtSked.send_addsked(wtskdlg.target_wt, wtskdlg.sked_time, wtskdlg.qrg, wtskdlg.band, wtskdlg.mode, wtskdlg.call, wtskdlg.notes);
+                        wtSked.send_unlocksked(wtskdlg.target_wt);
+                    }
                 }
             }
         }
@@ -3154,9 +3190,9 @@ namespace wtKST
             this.ss_Main = new System.Windows.Forms.StatusStrip();
             this.tsl_Info = new System.Windows.Forms.ToolStripStatusLabel();
             this.tsl_Error = new System.Windows.Forms.ToolStripStatusLabel();
+            this.tsl_LED_KST_Status = new System.Windows.Forms.ToolStripStatusLabel();
             this.tsl_LED_AS_Status = new System.Windows.Forms.ToolStripStatusLabel();
             this.tsl_LED_Log_Status = new System.Windows.Forms.ToolStripStatusLabel();
-            this.tsl_LED_KST_Status = new System.Windows.Forms.ToolStripStatusLabel();
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
             this.splitContainer2 = new System.Windows.Forms.SplitContainer();
             this.splitContainer3 = new System.Windows.Forms.SplitContainer();
@@ -3204,6 +3240,7 @@ namespace wtKST
             this.macro_default_Station = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
             this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.skedTestToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.ti_Main = new System.Windows.Forms.Timer(this.components);
             this.ni_Main = new System.Windows.Forms.NotifyIcon(this.components);
             this.cmn_Notify = new System.Windows.Forms.ContextMenuStrip(this.components);
@@ -3561,6 +3598,7 @@ namespace wtKST
             this.lv_Calls.CellValueChanged += new System.Windows.Forms.DataGridViewCellEventHandler(this.lv_Calls_CellValueChanged);
             this.lv_Calls.ColumnHeaderMouseClick += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.lv_Calls_ColumnClick);
             this.lv_Calls.DataBindingComplete += new System.Windows.Forms.DataGridViewBindingCompleteEventHandler(this.lv_DataBindingComplete);
+            this.lv_Calls.DataBindingComplete += new System.Windows.Forms.DataGridViewBindingCompleteEventHandler(this.lv_Calls_DataBindingComplete);
             this.lv_Calls.ClientSizeChanged += new System.EventHandler(this.lv_Calls_clientSizeChanged);
             this.lv_Calls.MouseWheel += new System.Windows.Forms.MouseEventHandler(this.lv_Calls_mousewheel_event);
             // 
@@ -3586,7 +3624,8 @@ namespace wtKST
             this.tsm_KST,
             this.tsi_Options,
             this.macroToolStripMenuItem,
-            this.toolStripMenuItem1});
+            this.toolStripMenuItem1,
+            this.skedTestToolStripMenuItem});
             this.mn_Main.Location = new System.Drawing.Point(0, 0);
             this.mn_Main.Name = "mn_Main";
             this.mn_Main.Size = new System.Drawing.Size(1202, 24);
@@ -3804,6 +3843,13 @@ namespace wtKST
             this.aboutToolStripMenuItem.Size = new System.Drawing.Size(107, 22);
             this.aboutToolStripMenuItem.Text = "&About";
             this.aboutToolStripMenuItem.Click += new System.EventHandler(this.aboutToolStripMenuItem_Click);
+            // 
+            // skedTestToolStripMenuItem
+            // 
+            this.skedTestToolStripMenuItem.Name = "skedTestToolStripMenuItem";
+            this.skedTestToolStripMenuItem.Size = new System.Drawing.Size(68, 20);
+            this.skedTestToolStripMenuItem.Text = "Sked Test";
+            this.skedTestToolStripMenuItem.Click += new System.EventHandler(this.skedTestToolStripMenuItem_Click);
             // 
             // ti_Main
             // 
@@ -4191,6 +4237,48 @@ namespace wtKST
             menu_btn_macro_0.Visible = Settings.Default.KST_M0;
             if (!Settings.Default.KST_Macro_9.Equals(menu_btn_macro_0.Text))
                 menu_btn_macro_0.Text = Settings.Default.KST_Macro_0;
+        }
+
+        private void skedTestToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            var msgSked = new NetworkMsgSked
+            {
+                Callsign = "M4W",
+                Comments = "From WTKST",
+                Frequency = 144222.ToString(),
+                Mode = "USB",
+                SkedTime = DateTime.UtcNow.AddMinutes(3)
+            };
+
+            var networkMessage = new NetworkMessage
+            {
+                MsgDestination = "ALL",
+                MsgSender = "WTKST",
+                MsgID = "1",
+                MsgType = "SKD",
+                MsgData = msgSked.ToByteArray()
+            };
+
+            var rawMessage = networkMessage.ToByteArray();
+
+            try
+            {
+                using (var udpClient = new UdpClient())
+                {
+                    udpClient.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.Broadcast, 1);
+                    udpClient.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, 1);
+                    udpClient.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.DontRoute, 1);
+                    udpClient.Client.ReceiveTimeout = 10000;
+                    var endPoint = new IPEndPoint(IPAddress.Parse("192.168.10.255"), 9888);
+                    udpClient.Connect(endPoint);
+
+                    udpClient.Send(rawMessage, rawMessage.Length);
+                    udpClient.Close();
+                }
+            }
+            catch
+            {
+            }
         }
     }
 }

--- a/wtKST/MainDlg.cs
+++ b/wtKST/MainDlg.cs
@@ -3862,6 +3862,7 @@ namespace wtKST
             this.skedTestToolStripMenuItem.Name = "skedTestToolStripMenuItem";
             this.skedTestToolStripMenuItem.Size = new System.Drawing.Size(68, 20);
             this.skedTestToolStripMenuItem.Text = "Sked Test";
+            this.skedTestToolStripMenuItem.Visible = false;
             this.skedTestToolStripMenuItem.Click += new System.EventHandler(this.skedTestToolStripMenuItem_Click);
             // 
             // ti_Main
@@ -4257,46 +4258,55 @@ namespace wtKST
                 menu_btn_macro_0.Text = Settings.Default.KST_Macro_0;
         }
 
-        private void skedTestToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            var msgSked = new NetworkMsgSked
-            {
-                Callsign = "M4W",
-                Comments = "From WTKST",
-                Frequency = 144222.ToString(),
-                Mode = "USB",
-                SkedTime = DateTime.UtcNow.AddMinutes(3)
-            };
+        // TODO: DXLog sked sending not fully implemented yet
+        //private void skedTestToolStripMenuItem_Click(object sender, EventArgs e)
+        //{
+        //    string skedTestCall = "M4W";
+        //    if (CALL.Rows.Count > 0)
+        //    {
+        //        var rng = new Random();
+        //        skedTestCall = CALL.Rows[rng.Next(CALL.Rows.Count)]["CALL"].ToString();
+        //    }
 
-            var networkMessage = new NetworkMessage
-            {
-                MsgDestination = "ALL",
-                MsgSender = "WTKST",
-                MsgID = "1",
-                MsgType = "SKD",
-                MsgData = msgSked.ToByteArray()
-            };
+        //    var msgSked = new NetworkMsgSked
+        //    {
+        //        Callsign = skedTestCall,
+        //        Comments = "From WTKST",
+        //        Frequency = 144222.ToString(),
+        //        Mode = "USB",
+        //        SkedTime = DateTime.UtcNow.AddMinutes(1)
+        //    };
 
-            var rawMessage = networkMessage.ToByteArray();
+        //    var networkMessage = new NetworkMessage
+        //    {
+        //        MsgDestination = !string.IsNullOrWhiteSpace(Settings.Default.DXLog_StationName) ? Settings.Default.DXLog_StationName : "ALL",
+        //        MsgSender = "WTKST",
+        //        MsgID = "1",
+        //        MsgType = "SKD",
+        //        MsgData = msgSked.ToByteArray()
+        //    };
 
-            try
-            {
-                using (var udpClient = new UdpClient())
-                {
-                    udpClient.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.Broadcast, 1);
-                    udpClient.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, 1);
-                    udpClient.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.DontRoute, 1);
-                    udpClient.Client.ReceiveTimeout = 10000;
-                    var endPoint = new IPEndPoint(IPAddress.Parse("192.168.10.255"), 9888);
-                    udpClient.Connect(endPoint);
+        //    var rawMessage = networkMessage.ToByteArray();
 
-                    udpClient.Send(rawMessage, rawMessage.Length);
-                    udpClient.Close();
-                }
-            }
-            catch
-            {
-            }
-        }
+        //    try
+        //    {
+        //        using (var udpClient = new UdpClient())
+        //        {
+        //            udpClient.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.Broadcast, 1);
+        //            udpClient.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, 1);
+        //            udpClient.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.DontRoute, 1);
+        //            udpClient.Client.ReceiveTimeout = 10000;
+        //            var endPoint = new IPEndPoint(WinTest.WinTest.GetIpIFBroadcastAddress(), 9888);
+        //            udpClient.Connect(endPoint);
+
+        //            udpClient.Send(rawMessage, rawMessage.Length);
+        //            udpClient.Close();
+        //        }
+        //    }
+        //    catch
+        //    {
+        //    }
+        //}
+        private void skedTestToolStripMenuItem_Click(object sender, EventArgs e) { }
     }
 }

--- a/wtKST/MainDlg.cs
+++ b/wtKST/MainDlg.cs
@@ -542,7 +542,16 @@ namespace wtKST
                 /* show number of calls in list and total number of users (-1 for own call) */
                 KST_Calls_Text = "Calls [" + lv_Calls.RowCount.ToString() + " / " + (CALL.Rows.Count - 1) + "]";
                 if (wtQSO != null)
-                    KST_Calls_Text += " - " + Path.GetFileName(wtQSO.getStatus());
+                {
+                    string intName;
+                    if (wtQSO is WinTest.WinTestLog)           intName = "WT File";
+                    else if (wtQSO is WinTest.WtLogSync)       intName = WinTest.WinTest.advancedNetActivated ? "WT Net (Advanced)" : "WT Net";
+                    else if (wtQSO is WinTest.QARTestLogSync)  intName = "QARTest";
+                    else if (wtQSO is N1MMSQLiteLog)           intName = "N1MM";
+                    else if (wtQSO is WinTest.DXL.DXLogSync)  intName = "DXLog";
+                    else                                       intName = "Log";
+                    KST_Calls_Text += " - " + intName + " " + wtQSO.QSO.Rows.Count + " QSOs";
+                }
             }
             else
             {

--- a/wtKST/OptionsDlg.cs
+++ b/wtKST/OptionsDlg.cs
@@ -1928,6 +1928,7 @@ namespace wtKST
             // 
             // tb_Options_DXLog_Station_Name
             // 
+            this.tb_Options_DXLog_Station_Name.Visible = false;
             this.tb_Options_DXLog_Station_Name.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::wtKST.Properties.Settings.Default, "DXLog_StationName", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
             this.tb_Options_DXLog_Station_Name.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.tb_Options_DXLog_Station_Name.Location = new System.Drawing.Point(112, 35);
@@ -1944,7 +1945,8 @@ namespace wtKST
             this.label28.Name = "label28";
             this.label28.Size = new System.Drawing.Size(74, 13);
             this.label28.TabIndex = 14;
-            this.label28.Text = "Station Name:";
+            this.label28.Text = "Sked Target Station:";
+            this.label28.Visible = false;
             // 
             // OptionsDlg
             // 

--- a/wtKST/OptionsDlg.cs
+++ b/wtKST/OptionsDlg.cs
@@ -127,6 +127,8 @@ namespace wtKST
         private Panel panel_WS;
         private Panel panel2;
         private Panel panel_AS;
+        private Label label_AS_Port;
+        private TextBox tb_AS_Port;
         private Label label_timeout2;
         private Label label29;
         private TextBox tb_WS_LoginURL;
@@ -340,6 +342,8 @@ namespace wtKST
             this.cb_AS_Active = new System.Windows.Forms.CheckBox();
             this.tb_AS_Timeout = new System.Windows.Forms.TextBox();
             this.tb_Options_AS_Local_Server_Name = new System.Windows.Forms.TextBox();
+            this.label_AS_Port = new System.Windows.Forms.Label();
+            this.tb_AS_Port = new System.Windows.Forms.TextBox();
             this.panel_WS = new System.Windows.Forms.Panel();
             this.tb_WS_Password = new System.Windows.Forms.TextBox();
             this.label31 = new System.Windows.Forms.Label();
@@ -1236,7 +1240,7 @@ namespace wtKST
             this.tabPage4.Controls.Add(this.panel_WS);
             this.tabPage4.Location = new System.Drawing.Point(4, 22);
             this.tabPage4.Name = "tabPage4";
-            this.tabPage4.Size = new System.Drawing.Size(471, 290);
+            this.tabPage4.Size = new System.Drawing.Size(471, 316);
             this.tabPage4.TabIndex = 2;
             this.tabPage4.Text = "Airplane Scatter";
             this.tabPage4.UseVisualStyleBackColor = true;
@@ -1382,6 +1386,8 @@ namespace wtKST
             // 
             // panel_AS
             // 
+            this.panel_AS.Controls.Add(this.label_AS_Port);
+            this.panel_AS.Controls.Add(this.tb_AS_Port);
             this.panel_AS.Controls.Add(this.label_local_server);
             this.panel_AS.Controls.Add(this.cb_AS_local);
             this.panel_AS.Controls.Add(this.label_timeout2);
@@ -1391,14 +1397,14 @@ namespace wtKST
             this.panel_AS.Controls.Add(this.tb_Options_AS_Local_Server_Name);
             this.panel_AS.Location = new System.Drawing.Point(5, 84);
             this.panel_AS.Name = "panel_AS";
-            this.panel_AS.Size = new System.Drawing.Size(446, 59);
+            this.panel_AS.Size = new System.Drawing.Size(446, 82);
             this.panel_AS.TabIndex = 35;
             // 
             // label_local_server
             // 
             this.label_local_server.AutoSize = true;
             this.label_local_server.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label_local_server.Location = new System.Drawing.Point(231, 37);
+            this.label_local_server.Location = new System.Drawing.Point(231, 60);
             this.label_local_server.Name = "label_local_server";
             this.label_local_server.Size = new System.Drawing.Size(70, 13);
             this.label_local_server.TabIndex = 11;
@@ -1410,7 +1416,7 @@ namespace wtKST
             this.cb_AS_local.Checked = global::wtKST.Properties.Settings.Default.AS_Local_Active;
             this.cb_AS_local.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::wtKST.Properties.Settings.Default, "AS_Local_Active", true, System.Windows.Forms.DataSourceUpdateMode.OnValidation));
             this.cb_AS_local.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.cb_AS_local.Location = new System.Drawing.Point(33, 35);
+            this.cb_AS_local.Location = new System.Drawing.Point(33, 58);
             this.cb_AS_local.Name = "cb_AS_local";
             this.cb_AS_local.Size = new System.Drawing.Size(177, 17);
             this.cb_AS_local.TabIndex = 7;
@@ -1423,7 +1429,7 @@ namespace wtKST
             // 
             this.label_timeout2.AutoSize = true;
             this.label_timeout2.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label_timeout2.Location = new System.Drawing.Point(414, 14);
+            this.label_timeout2.Location = new System.Drawing.Point(414, 37);
             this.label_timeout2.Name = "label_timeout2";
             this.label_timeout2.Size = new System.Drawing.Size(27, 13);
             this.label_timeout2.TabIndex = 20;
@@ -1433,7 +1439,7 @@ namespace wtKST
             // 
             this.label_timeout.AutoSize = true;
             this.label_timeout.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label_timeout.Location = new System.Drawing.Point(272, 14);
+            this.label_timeout.Location = new System.Drawing.Point(272, 37);
             this.label_timeout.Name = "label_timeout";
             this.label_timeout.Size = new System.Drawing.Size(109, 13);
             this.label_timeout.TabIndex = 13;
@@ -1445,7 +1451,7 @@ namespace wtKST
             this.cb_AS_Active.Checked = global::wtKST.Properties.Settings.Default.AS_Active;
             this.cb_AS_Active.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::wtKST.Properties.Settings.Default, "AS_Active", true, System.Windows.Forms.DataSourceUpdateMode.OnValidation));
             this.cb_AS_Active.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.cb_AS_Active.Location = new System.Drawing.Point(13, 13);
+            this.cb_AS_Active.Location = new System.Drawing.Point(13, 36);
             this.cb_AS_Active.Name = "cb_AS_Active";
             this.cb_AS_Active.Size = new System.Drawing.Size(243, 17);
             this.cb_AS_Active.TabIndex = 5;
@@ -1457,7 +1463,7 @@ namespace wtKST
             // 
             this.tb_AS_Timeout.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::wtKST.Properties.Settings.Default, "AS_Timeout", true, System.Windows.Forms.DataSourceUpdateMode.OnValidation));
             this.tb_AS_Timeout.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.tb_AS_Timeout.Location = new System.Drawing.Point(387, 10);
+            this.tb_AS_Timeout.Location = new System.Drawing.Point(387, 33);
             this.tb_AS_Timeout.Name = "tb_AS_Timeout";
             this.tb_AS_Timeout.Size = new System.Drawing.Size(23, 20);
             this.tb_AS_Timeout.TabIndex = 6;
@@ -1468,12 +1474,30 @@ namespace wtKST
             this.tb_Options_AS_Local_Server_Name.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::wtKST.Properties.Settings.Default, "AS_Local_Name", true, System.Windows.Forms.DataSourceUpdateMode.OnValidation));
             this.tb_Options_AS_Local_Server_Name.Enabled = global::wtKST.Properties.Settings.Default.AS_Local_Active;
             this.tb_Options_AS_Local_Server_Name.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.tb_Options_AS_Local_Server_Name.Location = new System.Drawing.Point(305, 33);
+            this.tb_Options_AS_Local_Server_Name.Location = new System.Drawing.Point(305, 56);
             this.tb_Options_AS_Local_Server_Name.Name = "tb_Options_AS_Local_Server_Name";
             this.tb_Options_AS_Local_Server_Name.Size = new System.Drawing.Size(51, 20);
             this.tb_Options_AS_Local_Server_Name.TabIndex = 8;
             this.tb_Options_AS_Local_Server_Name.Text = global::wtKST.Properties.Settings.Default.AS_Local_Name;
-            // 
+            //
+            // label_AS_Port
+            //
+            this.label_AS_Port.AutoSize = true;
+            this.label_AS_Port.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label_AS_Port.Location = new System.Drawing.Point(12, 13);
+            this.label_AS_Port.Name = "label_AS_Port";
+            this.label_AS_Port.Text = "AirScout UDP Port:";
+            //
+            // tb_AS_Port
+            //
+            this.tb_AS_Port.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::wtKST.Properties.Settings.Default, "AS_Port", true, System.Windows.Forms.DataSourceUpdateMode.OnValidation));
+            this.tb_AS_Port.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.tb_AS_Port.Location = new System.Drawing.Point(130, 10);
+            this.tb_AS_Port.Name = "tb_AS_Port";
+            this.tb_AS_Port.Size = new System.Drawing.Size(50, 20);
+            this.tb_AS_Port.TabIndex = 9;
+            this.tb_AS_Port.Text = global::wtKST.Properties.Settings.Default.AS_Port.ToString();
+            //
             // panel_WS
             // 
             this.panel_WS.Controls.Add(this.tb_WS_Password);
@@ -1485,7 +1509,7 @@ namespace wtKST
             this.panel_WS.Controls.Add(this.label_WS_Username);
             this.panel_WS.Controls.Add(this.tb_WS_Username);
             this.panel_WS.Controls.Add(this.cb_WS_Active);
-            this.panel_WS.Location = new System.Drawing.Point(5, 149);
+            this.panel_WS.Location = new System.Drawing.Point(5, 175);
             this.panel_WS.Name = "panel_WS";
             this.panel_WS.Size = new System.Drawing.Size(446, 138);
             this.panel_WS.TabIndex = 37;

--- a/wtKST/OptionsDlg.cs
+++ b/wtKST/OptionsDlg.cs
@@ -114,6 +114,10 @@ namespace wtKST
         private GroupBox groupBox1;
         private GroupBox groupBox4;
         public CheckBox cb_QARTest_Active;
+        private GroupBox groupBox6;
+        public CheckBox cb_DXLog_Active;
+        public TextBox tb_Options_DXLog_Station_Name;
+        private Label label28;
         public CheckBox cb_WS_Active;
         private Label label_WS_Password;
         private TextBox tb_WS_Password;
@@ -153,6 +157,8 @@ namespace wtKST
                 this.cb_QARTest_Active.Enabled = false;
                 this.cb_N1MM_Active.Checked = false;
                 this.cb_N1MM_Active.Enabled = false;
+                this.cb_DXLog_Active.Checked = false;
+                this.cb_DXLog_Active.Enabled = false;
             }
             else if (this.cb_WinTestNet_Active.Checked)
             {
@@ -163,6 +169,8 @@ namespace wtKST
                 this.cb_QARTest_Active.Enabled = false;
                 this.cb_N1MM_Active.Checked = false;
                 this.cb_N1MM_Active.Enabled = false;
+                this.cb_DXLog_Active.Checked = false;
+                this.cb_DXLog_Active.Enabled = false;
             }
             else if (this.cb_QARTest_Active.Checked)
             {
@@ -173,6 +181,8 @@ namespace wtKST
                 this.cb_WinTestNet_Active.Enabled = false;
                 this.cb_N1MM_Active.Checked = false;
                 this.cb_N1MM_Active.Enabled = false;
+                this.cb_DXLog_Active.Checked = false;
+                this.cb_DXLog_Active.Enabled = false;
             }
             else if (this.cb_N1MM_Active.Checked)
             {
@@ -183,6 +193,20 @@ namespace wtKST
                 this.cb_WinTestNet_Active.Enabled = false;
                 this.cb_QARTest_Active.Checked = false;
                 this.cb_QARTest_Active.Enabled = false;
+                this.cb_DXLog_Active.Checked = false;
+                this.cb_DXLog_Active.Enabled = false;
+            }
+            else if (this.cb_DXLog_Active.Checked)
+            {
+                this.cb_DXLog_Active.Enabled = true;
+                this.cb_WinTest_Active.Checked = false;
+                this.cb_WinTest_Active.Enabled = false;
+                this.cb_WinTestNet_Active.Checked = false;
+                this.cb_WinTestNet_Active.Enabled = false;
+                this.cb_QARTest_Active.Checked = false;
+                this.cb_QARTest_Active.Enabled = false;
+                this.cb_N1MM_Active.Checked = false;
+                this.cb_N1MM_Active.Enabled = false;
             }
             else
             {
@@ -191,6 +215,7 @@ namespace wtKST
                 this.cb_WinTestNet_Active.Enabled = true;
                 this.cb_QARTest_Active.Enabled = true;
                 this.cb_N1MM_Active.Enabled = true;
+                this.cb_DXLog_Active.Enabled = true;
             }
 
             // AS handling
@@ -268,6 +293,8 @@ namespace wtKST
             this.tb_KST_Password = new System.Windows.Forms.TextBox();
             this.tb_KST_UserName = new System.Windows.Forms.TextBox();
             this.tabPage2 = new System.Windows.Forms.TabPage();
+            this.groupBox6 = new System.Windows.Forms.GroupBox();
+            this.cb_DXLog_Active = new System.Windows.Forms.CheckBox();
             this.groupBox4 = new System.Windows.Forms.GroupBox();
             this.cb_QARTest_Active = new System.Windows.Forms.CheckBox();
             this.groupBox2 = new System.Windows.Forms.GroupBox();
@@ -364,11 +391,14 @@ namespace wtKST
             this.lbl_N1MM_Contest = new System.Windows.Forms.Label();
             this.cb_N1MM_Contest = new System.Windows.Forms.ComboBox();
             this.btn_N1MM_LoadContests = new System.Windows.Forms.Button();
+            this.tb_Options_DXLog_Station_Name = new System.Windows.Forms.TextBox();
+            this.label28 = new System.Windows.Forms.Label();
             this.groupBox3.SuspendLayout();
             this.groupBox5.SuspendLayout();
             this.tabControl1.SuspendLayout();
             this.tabPage1.SuspendLayout();
             this.tabPage2.SuspendLayout();
+            this.groupBox6.SuspendLayout();
             this.groupBox4.SuspendLayout();
             this.groupBox2.SuspendLayout();
             this.groupBox1.SuspendLayout();
@@ -535,7 +565,7 @@ namespace wtKST
             this.tabControl1.Location = new System.Drawing.Point(12, 12);
             this.tabControl1.Name = "tabControl1";
             this.tabControl1.SelectedIndex = 0;
-            this.tabControl1.Size = new System.Drawing.Size(479, 316);
+            this.tabControl1.Size = new System.Drawing.Size(479, 367);
             this.tabControl1.TabIndex = 0;
             // 
             // tabPage1
@@ -703,12 +733,13 @@ namespace wtKST
             //
             this.tabPage2.AutoScroll = true;
             this.tabPage2.Controls.Add(this.groupBox_N1MM);
+            this.tabPage2.Controls.Add(this.groupBox6);
             this.tabPage2.Controls.Add(this.groupBox4);
             this.tabPage2.Controls.Add(this.groupBox2);
             this.tabPage2.Controls.Add(this.groupBox1);
             this.tabPage2.Location = new System.Drawing.Point(4, 22);
             this.tabPage2.Name = "tabPage2";
-            this.tabPage2.Size = new System.Drawing.Size(471, 290);
+            this.tabPage2.Size = new System.Drawing.Size(471, 341);
             this.tabPage2.TabIndex = 0;
             this.tabPage2.Text = "Log";
             this.tabPage2.UseVisualStyleBackColor = true;
@@ -828,14 +859,44 @@ namespace wtKST
             this.btn_N1MM_LoadContests.Text = "Load";
             this.btn_N1MM_LoadContests.UseVisualStyleBackColor = true;
             this.btn_N1MM_LoadContests.Click += new System.EventHandler(this.btn_N1MM_LoadContests_Click);
+            //
+            // groupBox6
+            //
+            this.groupBox6.Controls.Add(this.tb_Options_DXLog_Station_Name);
+            this.groupBox6.Controls.Add(this.label28);
+            this.groupBox6.Controls.Add(this.cb_DXLog_Active);
+            this.groupBox6.Location = new System.Drawing.Point(22, 199);
+            this.groupBox6.Margin = new System.Windows.Forms.Padding(2);
+            this.groupBox6.Name = "groupBox6";
+            this.groupBox6.Padding = new System.Windows.Forms.Padding(2);
+            this.groupBox6.Size = new System.Drawing.Size(422, 64);
+            this.groupBox6.TabIndex = 19;
+            this.groupBox6.TabStop = false;
+            this.groupBox6.Text = "DXLog Network sync";
+            //
+            // cb_DXLog_Active
+            //
+            this.cb_DXLog_Active.AutoSize = true;
+            this.cb_DXLog_Active.Checked = global::wtKST.Properties.Settings.Default.DXLog_Sync_active;
+            this.cb_DXLog_Active.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::wtKST.Properties.Settings.Default, "DXLog_Sync_active", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.cb_DXLog_Active.Enabled = false;
+            this.cb_DXLog_Active.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.cb_DXLog_Active.Location = new System.Drawing.Point(8, 22);
+            this.cb_DXLog_Active.Name = "cb_DXLog_Active";
+            this.cb_DXLog_Active.Size = new System.Drawing.Size(65, 17);
+            this.cb_DXLog_Active.TabIndex = 10;
+            this.cb_DXLog_Active.Text = "Activate";
+            this.cb_DXLog_Active.UseVisualStyleBackColor = true;
+            this.cb_DXLog_Active.CheckedChanged += new System.EventHandler(this.cb_DXLog_Active_CheckedChanged);
+            //
             // groupBox4
             //
             this.groupBox4.Controls.Add(this.cb_QARTest_Active);
-            this.groupBox4.Location = new System.Drawing.Point(22, 198);
+            this.groupBox4.Location = new System.Drawing.Point(22, 281);
             this.groupBox4.Margin = new System.Windows.Forms.Padding(2);
             this.groupBox4.Name = "groupBox4";
             this.groupBox4.Padding = new System.Windows.Forms.Padding(2);
-            this.groupBox4.Size = new System.Drawing.Size(422, 64);
+            this.groupBox4.Size = new System.Drawing.Size(173, 46);
             this.groupBox4.TabIndex = 17;
             this.groupBox4.TabStop = false;
             this.groupBox4.Text = "QARTest Network sync";
@@ -1841,13 +1902,33 @@ namespace wtKST
             this.cB_macro_1.TabIndex = 11;
             this.cB_macro_1.UseVisualStyleBackColor = true;
             // 
+            // tb_Options_DXLog_Station_Name
+            // 
+            this.tb_Options_DXLog_Station_Name.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::wtKST.Properties.Settings.Default, "DXLog_StationName", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.tb_Options_DXLog_Station_Name.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.tb_Options_DXLog_Station_Name.Location = new System.Drawing.Point(112, 35);
+            this.tb_Options_DXLog_Station_Name.Name = "tb_Options_DXLog_Station_Name";
+            this.tb_Options_DXLog_Station_Name.Size = new System.Drawing.Size(204, 20);
+            this.tb_Options_DXLog_Station_Name.TabIndex = 15;
+            this.tb_Options_DXLog_Station_Name.Text = global::wtKST.Properties.Settings.Default.DXLog_StationName;
+            // 
+            // label28
+            // 
+            this.label28.AutoSize = true;
+            this.label28.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label28.Location = new System.Drawing.Point(5, 42);
+            this.label28.Name = "label28";
+            this.label28.Size = new System.Drawing.Size(74, 13);
+            this.label28.TabIndex = 14;
+            this.label28.Text = "Station Name:";
+            // 
             // OptionsDlg
             // 
             this.AcceptButton = this.btn_OK;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.btn_Cancel;
-            this.ClientSize = new System.Drawing.Size(617, 350);
+            this.ClientSize = new System.Drawing.Size(617, 394);
             this.Controls.Add(this.tabControl1);
             this.Controls.Add(this.btn_Cancel);
             this.Controls.Add(this.btn_OK);
@@ -1865,6 +1946,8 @@ namespace wtKST
             this.tabPage2.ResumeLayout(false);
             this.groupBox_N1MM.ResumeLayout(false);
             this.groupBox_N1MM.PerformLayout();
+            this.groupBox6.ResumeLayout(false);
+            this.groupBox6.PerformLayout();
             this.groupBox4.ResumeLayout(false);
             this.groupBox4.PerformLayout();
             this.groupBox2.ResumeLayout(false);
@@ -1932,12 +2015,16 @@ namespace wtKST
                 this.cb_QARTest_Active.Enabled = false;
                 this.cb_N1MM_Active.Checked = false;
                 this.cb_N1MM_Active.Enabled = false;
+                this.cb_DXLog_Active.Checked = false;
+                this.cb_DXLog_Active.Enabled = false;
             }
             else
             {
+                this.cb_WinTest_Active.Enabled = true;
                 this.cb_WinTestNet_Active.Enabled = true;
                 this.cb_QARTest_Active.Enabled = true;
                 this.cb_N1MM_Active.Enabled = true;
+                this.cb_DXLog_Active.Enabled = true;
             }
         }
         private void cb_WinTestNet_Active_CheckedChanged(object sender, EventArgs e)
@@ -1950,12 +2037,16 @@ namespace wtKST
                 this.cb_QARTest_Active.Enabled = false;
                 this.cb_N1MM_Active.Checked = false;
                 this.cb_N1MM_Active.Enabled = false;
+                this.cb_DXLog_Active.Checked = false;
+                this.cb_DXLog_Active.Enabled = false;
             }
             else
             {
                 this.cb_WinTest_Active.Enabled = true;
+                this.cb_WinTestNet_Active.Enabled = true;
                 this.cb_QARTest_Active.Enabled = true;
                 this.cb_N1MM_Active.Enabled = true;
+                this.cb_DXLog_Active.Enabled = true;
             }
         }
         private void cb_QARTest_Active_CheckedChanged(object sender, EventArgs e)
@@ -1968,12 +2059,16 @@ namespace wtKST
                 this.cb_WinTestNet_Active.Enabled = false;
                 this.cb_N1MM_Active.Checked = false;
                 this.cb_N1MM_Active.Enabled = false;
+                this.cb_DXLog_Active.Checked = false;
+                this.cb_DXLog_Active.Enabled = false;
             }
             else
             {
                 this.cb_WinTest_Active.Enabled = true;
                 this.cb_WinTestNet_Active.Enabled = true;
+                this.cb_QARTest_Active.Enabled = true;
                 this.cb_N1MM_Active.Enabled = true;
+                this.cb_DXLog_Active.Enabled = true;
             }
         }
 
@@ -1987,12 +2082,37 @@ namespace wtKST
                 this.cb_WinTestNet_Active.Enabled = false;
                 this.cb_QARTest_Active.Checked = false;
                 this.cb_QARTest_Active.Enabled = false;
+                this.cb_DXLog_Active.Checked = false;
+                this.cb_DXLog_Active.Enabled = false;
             }
             else
             {
                 this.cb_WinTest_Active.Enabled = true;
                 this.cb_WinTestNet_Active.Enabled = true;
                 this.cb_QARTest_Active.Enabled = true;
+                this.cb_DXLog_Active.Enabled = true;
+            }
+        }
+
+        private void cb_DXLog_Active_CheckedChanged(object sender, EventArgs e)
+        {
+            if (this.cb_DXLog_Active.Checked)
+            {
+                this.cb_WinTest_Active.Checked = false;
+                this.cb_WinTest_Active.Enabled = false;
+                this.cb_WinTestNet_Active.Checked = false;
+                this.cb_WinTestNet_Active.Enabled = false;
+                this.cb_QARTest_Active.Checked = false;
+                this.cb_QARTest_Active.Enabled = false;
+                this.cb_N1MM_Active.Checked = false;
+                this.cb_N1MM_Active.Enabled = false;
+            }
+            else
+            {
+                this.cb_WinTest_Active.Enabled = true;
+                this.cb_WinTestNet_Active.Enabled = true;
+                this.cb_QARTest_Active.Enabled = true;
+                this.cb_N1MM_Active.Enabled = true;
             }
         }
 


### PR DESCRIPTION
Tested / fixed the DXLog _log_ integration originally written by James M1DST.
It's using the DXLog network protocol to load in QSOs at wtKst telnet connection and then uses the UDP broadcast to keep in sync. Sked creation not yet working.

Green band coloring is now refreshed every 5 seconds.
AirScout port now configurable via Options